### PR TITLE
Adding RDP RGBA exactly 4 channels specialization

### DIFF
--- a/app/benches/rdp/main.rs
+++ b/app/benches/rdp/main.rs
@@ -300,12 +300,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let dimensions = img.dimensions();
     let binding = img.to_rgba8();
     let src_bytes = binding.as_bytes();
+    let src_bytes_rgb = img.to_rgb8();
 
     let mut plane =
         YuvPlanarImageMut::alloc(dimensions.0, dimensions.1, YuvChromaSubsampling::Yuv444);
-    c.bench_function("Rdp", |b| {
+    c.bench_function("Rdp Rgba", |b| {
         b.iter(|| {
             rdp_rgba_to_yuv444(&mut plane, src_bytes, dimensions.0 * 4).unwrap();
+        })
+    });
+
+    c.bench_function("Rdp Rgb", |b| {
+        b.iter(|| {
+            rdp_rgb_to_yuv444(&mut plane, &src_bytes_rgb, dimensions.0 * 3).unwrap();
         })
     });
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -33,14 +33,7 @@ use image::{ColorType, DynamicImage, EncodableLayout, GenericImageView, ImageRea
 use std::fs::File;
 use std::io::Read;
 use std::time::Instant;
-use yuv::{
-    i010_alpha_to_rgba10, i010_to_rgba10, icgc_re010_to_rgba, icgc_ro010_to_rgba,
-    icgc_ro210_to_rgba, icgc_ro410_to_rgba, rgba10_to_i010, rgba12_to_i412, rgba_to_icgc_re010,
-    rgba_to_icgc_ro010, rgba_to_icgc_ro210, rgba_to_icgc_ro410, rgba_to_ycgco420, rgba_to_ycgco444,
-    rgba_to_yuv420, ycgco420_to_rgba, ycgco444_to_rgba, yuv420_alpha_to_rgba, yuv420_to_rgba,
-    YuvBiPlanarImageMut, YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut,
-    YuvPlanarImageWithAlpha, YuvRange, YuvStandardMatrix,
-};
+use yuv::{i010_alpha_to_rgba10, i010_to_rgba10, icgc_re010_to_rgba, icgc_ro010_to_rgba, icgc_ro210_to_rgba, icgc_ro410_to_rgba, rdp_rgba_to_yuv444, rdp_yuv444_to_rgba, rgba10_to_i010, rgba12_to_i412, rgba_to_icgc_re010, rgba_to_icgc_ro010, rgba_to_icgc_ro210, rgba_to_icgc_ro410, rgba_to_ycgco420, rgba_to_ycgco444, rgba_to_yuv420, ycgco420_to_rgba, ycgco444_to_rgba, yuv420_alpha_to_rgba, yuv420_to_rgba, YuvBiPlanarImageMut, YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, YuvPlanarImageWithAlpha, YuvRange, YuvStandardMatrix};
 
 fn read_file_bytes(file_path: &str) -> Result<Vec<u8>, String> {
     // Open the file
@@ -58,7 +51,7 @@ fn read_file_bytes(file_path: &str) -> Result<Vec<u8>, String> {
 use core::f16;
 
 fn main() {
-    let mut img = ImageReader::open("./assets/jpeg_test.jpeg")
+    let mut img = ImageReader::open("./assets/bench.jpg")
         .unwrap()
         .decode()
         .unwrap();
@@ -94,20 +87,18 @@ fn main() {
     let mut uv_nv_plane = vec![0u8; width as usize * (height as usize + 1) / 2];
 
     let mut planar_image =
-        YuvPlanarImageMut::<u16>::alloc(width as u32, height as u32, YuvChromaSubsampling::Yuv420);
-    //
-    let mut bytes_16: Vec<u16> = src_bytes
-        .iter()
-        .map(|&x| ((x as u16) << 2) | ((x as u16) >> 6))
-        .collect();
+        YuvPlanarImageMut::<i16>::alloc(width as u32, height as u32, YuvChromaSubsampling::Yuv444);
+    // //
+    // let mut bytes_16: Vec<u16> = src_bytes
+    //     .iter()
+    //     .map(|&x| ((x as u16) << 2) | ((x as u16) >> 6))
+    //     .collect();
 
     let start_time = Instant::now();
-    rgba10_to_i010(
+    rdp_rgba_to_yuv444(
         &mut planar_image,
-        &bytes_16,
+        &src_bytes,
         rgba_stride as u32,
-        YuvRange::Limited,
-        YuvStandardMatrix::Bt709,
     )
     .unwrap();
 
@@ -115,33 +106,9 @@ fn main() {
     let fixed = planar_image.to_fixed();
     rgba.fill(255);
 
-    let a_plane = vec![1023; height as usize * width as usize];
-
-    let alpha = YuvPlanarImageWithAlpha {
-        y_plane: planar_image.y_plane.borrow(),
-        y_stride: planar_image.y_stride,
-        u_plane: planar_image.u_plane.borrow(),
-        u_stride: planar_image.u_stride,
-        v_plane: planar_image.v_plane.borrow(),
-        v_stride: planar_image.v_stride,
-        a_plane: &a_plane,
-        a_stride: width as u32,
-        width,
-        height,
-    };
-
-    i010_alpha_to_rgba10(
-        &alpha,
-        &mut bytes_16,
-        rgba_stride as u32,
-        YuvRange::Limited,
-        YuvStandardMatrix::Bt709,
-    )
-    .unwrap();
-
     //
     // let fixed_biplanar = bi_planar_image.to_fixed();
-    // let fixed_planar = planar_image.to_fixed();
+    let fixed_planar = planar_image.to_fixed();
     // // bytes_16.fill(0);
     //
     // let mut j_rgba = vec![0u8; dimensions.0 as usize * dimensions.1 as usize * 4];
@@ -163,16 +130,14 @@ fn main() {
     // // convert_rgb_f16_to_rgb(&rgba_f16, rgba_stride, &mut rgba, rgba_stride, width as usize, height as usize).unwrap();
     //
 
-    // i412_to_rgba12(
-    //     &fixed_planar,
-    //     &mut bytes_16,
-    //     dimensions.0 as u32 * 4,
-    //     YuvRange::Limited,
-    //     YuvStandardMatrix::Bt709,
-    // )
-    // .unwrap();
+    rdp_yuv444_to_rgba(
+        &fixed_planar,
+        &mut rgba,
+        dimensions.0 as u32 * 4,
+    )
+    .unwrap();
 
-    rgba = bytes_16.iter().map(|&x| (x >> 2) as u8).collect();
+    // rgba = bytes_16.iter().map(|&x| (x >> 2) as u8).collect();
 
     // rgba = rgba_f16.iter().map(|&x| (x as f32 * 255.) as u8).collect();
 

--- a/src/avx2/rdp_to_yuv.rs
+++ b/src/avx2/rdp_to_yuv.rs
@@ -29,7 +29,7 @@
 
 use crate::avx2::avx2_utils::{
     _mm256_deinterleave_rgba_epi8, _mm256_double_affine_uv_dot, _mm256_double_affine_uv_s_dot,
-    avx2_deinterleave_rgb,
+    avx2_deinterleave_rgb, shuffle,
 };
 use crate::internals::ProcessedOffset;
 use crate::rdp::RdpChannels;
@@ -48,9 +48,20 @@ pub(crate) fn rdp_avx2_rgba_to_yuv<const ORIGIN_CHANNELS: u8, const Q: i32>(
     width: usize,
 ) -> ProcessedOffset {
     unsafe {
-        rdp_avx2_rgba_to_yuv_impl::<ORIGIN_CHANNELS, Q>(
-            transform, y_plane, u_plane, v_plane, rgba, width,
-        )
+        let source_channels: RdpChannels = ORIGIN_CHANNELS.into();
+        if source_channels == RdpChannels::Abgr
+            || source_channels == RdpChannels::Argb
+            || source_channels == RdpChannels::Bgra
+            || source_channels == RdpChannels::Rgba
+        {
+            rdp_avx2_4chan_to_yuv_impl::<ORIGIN_CHANNELS, Q>(
+                transform, y_plane, u_plane, v_plane, rgba, width,
+            )
+        } else {
+            rdp_avx2_rgba_to_yuv_impl::<ORIGIN_CHANNELS, Q>(
+                transform, y_plane, u_plane, v_plane, rgba, width,
+            )
+        }
     }
 }
 
@@ -292,6 +303,466 @@ unsafe fn rdp_avx2_rgba_to_yuv_impl<const ORIGIN_CHANNELS: u8, const Q: i32>(
             v_buffer.get_unchecked_mut(16..).as_mut_ptr() as *mut __m256i,
             cr_vl.1,
         );
+
+        std::ptr::copy_nonoverlapping(
+            u_buffer.as_ptr(),
+            u_plane.get_unchecked_mut(ux..).as_mut_ptr(),
+            diff,
+        );
+        std::ptr::copy_nonoverlapping(
+            v_buffer.as_ptr(),
+            v_plane.get_unchecked_mut(ux..).as_mut_ptr(),
+            diff,
+        );
+
+        std::ptr::copy_nonoverlapping(
+            y_buffer.as_ptr(),
+            y_plane.get_unchecked_mut(cx..).as_mut_ptr(),
+            diff,
+        );
+
+        cx += diff;
+        ux += diff;
+    }
+
+    ProcessedOffset { ux, cx }
+}
+
+impl CbCrForwardTransform<i32> {
+    #[inline]
+    fn rdp_avx_make_transform_y(&self, cn: RdpChannels) -> [i16; 16] {
+        match cn {
+            RdpChannels::Rgba => [
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+            ],
+            RdpChannels::Bgra => [
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+            ],
+            RdpChannels::Abgr => [
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+                0,
+                self.yb as i16,
+                self.yg as i16,
+                self.yr as i16,
+            ],
+            RdpChannels::Argb => [
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+                0,
+                self.yr as i16,
+                self.yg as i16,
+                self.yb as i16,
+            ],
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn rdp_avx_make_transform_cb(&self, cn: RdpChannels) -> [i16; 16] {
+        match cn {
+            RdpChannels::Rgba => [
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+            ],
+            RdpChannels::Bgra => [
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+            ],
+            RdpChannels::Abgr => [
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+                0,
+                self.cb_b as i16,
+                self.cb_g as i16,
+                self.cb_r as i16,
+            ],
+            RdpChannels::Argb => [
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+                0,
+                self.cb_r as i16,
+                self.cb_g as i16,
+                self.cb_b as i16,
+            ],
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn rdp_avx_make_transform_cr(&self, cn: RdpChannels) -> [i16; 16] {
+        match cn {
+            RdpChannels::Rgba => [
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+            ],
+            RdpChannels::Bgra => [
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+            ],
+            RdpChannels::Abgr => [
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+                0,
+                self.cr_b as i16,
+                self.cr_g as i16,
+                self.cr_r as i16,
+            ],
+            RdpChannels::Argb => [
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+                0,
+                self.cr_r as i16,
+                self.cr_g as i16,
+                self.cr_b as i16,
+            ],
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn rdp_avx2_4chan_to_yuv_impl<const ORIGIN_CHANNELS: u8, const Q: i32>(
+    transform: &CbCrForwardTransform<i32>,
+    y_plane: &mut [i16],
+    u_plane: &mut [i16],
+    v_plane: &mut [i16],
+    rgba: &[u8],
+    width: usize,
+) -> ProcessedOffset {
+    let source_channels: RdpChannels = ORIGIN_CHANNELS.into();
+    assert!(
+        source_channels == RdpChannels::Abgr
+            || source_channels == RdpChannels::Argb
+            || source_channels == RdpChannels::Bgra
+            || source_channels == RdpChannels::Rgba
+    );
+    let channels = source_channels.get_channels_count();
+
+    let src_ptr = rgba;
+    let y_transform = _mm256_loadu_si256(
+        transform.rdp_avx_make_transform_y(source_channels).as_ptr() as *const __m256i,
+    );
+    let cb_transform = _mm256_loadu_si256(
+        transform
+            .rdp_avx_make_transform_cb(source_channels)
+            .as_ptr() as *const __m256i,
+    );
+    let cr_transform = _mm256_loadu_si256(
+        transform
+            .rdp_avx_make_transform_cr(source_channels)
+            .as_ptr() as *const __m256i,
+    );
+    let j_y_bias = _mm256_set1_epi32(4096);
+
+    let mut cx = 0;
+    let mut ux = 0;
+
+    while cx + 16 < width {
+        let src_ptr = src_ptr.get_unchecked(cx * channels..);
+
+        let row_z0 = _mm256_loadu_si256(src_ptr.as_ptr() as *const _);
+
+        let row0_z0 = _mm256_unpacklo_epi8(row_z0, _mm256_setzero_si256());
+        let row1_z0 = _mm256_unpackhi_epi8(row_z0, _mm256_setzero_si256());
+
+        let row_z1 = _mm256_loadu_si256(src_ptr.get_unchecked(32..).as_ptr() as *const _);
+
+        let y_row0 = _mm256_madd_epi16(row0_z0, y_transform);
+        let y_row1 = _mm256_madd_epi16(row1_z0, y_transform);
+        let cb_row0 = _mm256_madd_epi16(row0_z0, cb_transform);
+        let cb_row1 = _mm256_madd_epi16(row1_z0, cb_transform);
+        let cr_row0 = _mm256_madd_epi16(row0_z0, cr_transform);
+        let cr_row1 = _mm256_madd_epi16(row1_z0, cr_transform);
+
+        const M: i32 = shuffle(3, 1, 2, 0);
+
+        let mut f_y0 = _mm256_hadd_epi32(y_row0, y_row1);
+        let mut f_cb0 = _mm256_hadd_epi32(cb_row0, cb_row1);
+        let mut f_cr0 = _mm256_hadd_epi32(cr_row0, cr_row1);
+
+        let row0_z1 = _mm256_unpacklo_epi8(row_z1, _mm256_setzero_si256());
+        let row1_z1 = _mm256_unpackhi_epi8(row_z1, _mm256_setzero_si256());
+
+        let y1_row0 = _mm256_madd_epi16(row0_z1, y_transform);
+        let y1_row1 = _mm256_madd_epi16(row1_z1, y_transform);
+        let cb1_row0 = _mm256_madd_epi16(row0_z1, cb_transform);
+        let cb1_row1 = _mm256_madd_epi16(row1_z1, cb_transform);
+        let cr1_row0 = _mm256_madd_epi16(row0_z1, cr_transform);
+        let cr1_row1 = _mm256_madd_epi16(row1_z1, cr_transform);
+
+        f_y0 = _mm256_srai_epi32::<Q>(f_y0);
+        f_cb0 = _mm256_srai_epi32::<Q>(f_cb0);
+        f_cr0 = _mm256_srai_epi32::<Q>(f_cr0);
+
+        let mut f_y1 = _mm256_hadd_epi32(y1_row0, y1_row1);
+        let mut f_cb1 = _mm256_hadd_epi32(cb1_row0, cb1_row1);
+        let mut f_cr1 = _mm256_hadd_epi32(cr1_row0, cr1_row1);
+
+        f_y1 = _mm256_srai_epi32::<Q>(f_y1);
+        f_cb1 = _mm256_srai_epi32::<Q>(f_cb1);
+        f_cr1 = _mm256_srai_epi32::<Q>(f_cr1);
+
+        f_y0 = _mm256_sub_epi32(f_y0, j_y_bias);
+        f_y1 = _mm256_sub_epi32(f_y1, j_y_bias);
+
+        let z_y = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_y0, f_y1));
+        let z_cb = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cb0, f_cb1));
+        let z_cr = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cr0, f_cr1));
+
+        _mm256_storeu_si256(u_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _, z_cb);
+        _mm256_storeu_si256(v_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _, z_cr);
+        _mm256_storeu_si256(y_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _, z_y);
+
+        ux += 16;
+        cx += 16;
+    }
+
+    while cx + 8 < width {
+        let src_ptr = src_ptr.get_unchecked(cx * channels..);
+
+        let row = _mm256_loadu_si256(src_ptr.as_ptr() as *const _);
+
+        let row0 = _mm256_unpacklo_epi8(row, _mm256_setzero_si256());
+        let row1 = _mm256_unpackhi_epi8(row, _mm256_setzero_si256());
+
+        let y_row0 = _mm256_madd_epi16(row0, y_transform);
+        let y_row1 = _mm256_madd_epi16(row1, y_transform);
+        let cb_row0 = _mm256_madd_epi16(row0, cb_transform);
+        let cb_row1 = _mm256_madd_epi16(row1, cb_transform);
+        let cr_row0 = _mm256_madd_epi16(row0, cr_transform);
+        let cr_row1 = _mm256_madd_epi16(row1, cr_transform);
+
+        const M: i32 = shuffle(3, 1, 2, 0);
+
+        let mut f_y = _mm256_hadd_epi32(y_row0, y_row1);
+        let mut f_cb = _mm256_hadd_epi32(cb_row0, cb_row1);
+        let mut f_cr = _mm256_hadd_epi32(cr_row0, cr_row1);
+
+        f_y = _mm256_srai_epi32::<Q>(f_y);
+        f_cb = _mm256_srai_epi32::<Q>(f_cb);
+        f_cr = _mm256_srai_epi32::<Q>(f_cr);
+
+        f_y = _mm256_sub_epi32(f_y, j_y_bias);
+
+        let z_y = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_y, _mm256_setzero_si256()));
+        let z_cb = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cb, _mm256_setzero_si256()));
+        let z_cr = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cr, _mm256_setzero_si256()));
+
+        _mm_storeu_si128(
+            u_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _,
+            _mm256_castsi256_si128(z_cb),
+        );
+        _mm_storeu_si128(
+            v_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _,
+            _mm256_castsi256_si128(z_cr),
+        );
+        _mm_storeu_si128(
+            y_plane.get_unchecked_mut(ux..).as_mut_ptr() as *mut _,
+            _mm256_castsi256_si128(z_y),
+        );
+
+        ux += 8;
+        cx += 8;
+    }
+
+    if cx < width {
+        let diff = width - cx;
+        assert!(diff <= 8);
+        let mut src_buffer: [u8; 32] = [0; 32];
+        let mut y_buffer: [i16; 8] = [0; 8];
+        let mut u_buffer: [i16; 8] = [0; 8];
+        let mut v_buffer: [i16; 8] = [0; 8];
+
+        std::ptr::copy_nonoverlapping(
+            rgba.get_unchecked(cx * channels..).as_ptr(),
+            src_buffer.as_mut_ptr(),
+            diff * channels,
+        );
+
+        let row = _mm256_loadu_si256(src_buffer.as_ptr() as *const _);
+
+        let row0 = _mm256_unpacklo_epi8(row, _mm256_setzero_si256());
+        let row1 = _mm256_unpackhi_epi8(row, _mm256_setzero_si256());
+
+        let y_row0 = _mm256_madd_epi16(row0, y_transform);
+        let y_row1 = _mm256_madd_epi16(row1, y_transform);
+        let cb_row0 = _mm256_madd_epi16(row0, cb_transform);
+        let cb_row1 = _mm256_madd_epi16(row1, cb_transform);
+        let cr_row0 = _mm256_madd_epi16(row0, cr_transform);
+        let cr_row1 = _mm256_madd_epi16(row1, cr_transform);
+
+        const M: i32 = shuffle(3, 1, 2, 0);
+
+        let mut f_y = _mm256_hadd_epi32(y_row0, y_row1);
+        let mut f_cb = _mm256_hadd_epi32(cb_row0, cb_row1);
+        let mut f_cr = _mm256_hadd_epi32(cr_row0, cr_row1);
+
+        f_y = _mm256_srai_epi32::<Q>(f_y);
+        f_cb = _mm256_srai_epi32::<Q>(f_cb);
+        f_cr = _mm256_srai_epi32::<Q>(f_cr);
+
+        f_y = _mm256_sub_epi32(f_y, j_y_bias);
+
+        let z_y = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_y, _mm256_setzero_si256()));
+        let z_cb = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cb, _mm256_setzero_si256()));
+        let z_cr = _mm256_permute4x64_epi64::<M>(_mm256_packs_epi32(f_cr, _mm256_setzero_si256()));
+
+        _mm_storeu_si128(
+            u_buffer.as_mut_ptr() as *mut _,
+            _mm256_castsi256_si128(z_cb),
+        );
+        _mm_storeu_si128(
+            v_buffer.as_mut_ptr() as *mut _,
+            _mm256_castsi256_si128(z_cr),
+        );
+        _mm_storeu_si128(y_buffer.as_mut_ptr() as *mut _, _mm256_castsi256_si128(z_y));
 
         std::ptr::copy_nonoverlapping(
             u_buffer.as_ptr(),


### PR DESCRIPTION
cc @elmarco 

I did some specialization on 4 channels path, what gives some reasonable boost. If you like it I can keep it.

```bash
Rdp Rgba                time:   [983.88 µs 986.68 µs 989.58 µs]
                        change: [-9.3520% -8.9869% -8.5837%] (p = 0.00 < 0.05)
                        Performance has improved.
```