### PR TITLE
fix check_interleaved_chroma_channel() error: ChromaPlaneSizeMismatch

### DIFF
--- a/src/yuv_error.rs
+++ b/src/yuv_error.rs
@@ -266,7 +266,6 @@ pub(crate) fn check_interleaved_chroma_channel<V>(
         }));
     }
     if stride as usize * chroma_height as usize != data.len()
-        || chroma_min_width as usize * chroma_height as usize != data.len()
     {
         return Err(YuvError::ChromaPlaneSizeMismatch(MismatchedSize {
             expected: stride as usize * chroma_height as usize,


### PR DESCRIPTION
The meaning of stride is greater than or equal to width. 

If stride > width, this judgment condition will not be satisfied and it is WRONG.