### PR TITLE
Bench: Fix geometry bench

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-yuv = { path = "..", features = ["fast_mode", "sse", "avx", "professional_mode", "rdp", "ycgco_r_type", "nightly_i8mm", "rdm"], default-features = false }
+yuv = { path = "..", features = ["fast_mode", "sse", "avx", "professional_mode", "rdp", "ycgco_r_type", "nightly_i8mm", "rdm", "geometry"], default-features = false }
 image = { version = "0.25.5", default-features = false, features = ["png", "jpeg"] }
 yuv-sys = "0.3.7"
 rand = "0.9.0"


### PR DESCRIPTION
Broken at https://github.com/awxkee/yuvutils-rs/commit/9fadf67c57e2413200a3b60e488f953c309f572f

Fixes error with `cargo bench --bench geometry --manifest-path ./app/Cargo.toml`:
```
error[E0432]: unresolved imports `yuv::rotate_plane`, `yuv::rotate_rgba`, `yuv::RotationMode`
   --> app/benches/geometry/main.rs:31:11
    |
 31 | use yuv::{rotate_plane, rotate_rgba, RotationMode};
    |           ^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^ no `RotationMode` in the root
    |           |             |
    |           |             no `rotate_rgba` in the root
    |           no `rotate_plane` in the root
    |
note: found an item that was configured out
   --> /home/rgonzalez/src/github.com/awxkee/yuvutils-rs/src/lib.rs:529:33
    |
527 | #[cfg(feature = "geometry")]
    |       -------------------- the item is gated behind the `geometry` feature
528 | pub use geometry::{
529 |     rotate_cbcr, rotate_cbcr16, rotate_plane, rotate_plane16, rotate_rgb, rotate_rgb16,
    |                                 ^^^^^^^^^^^^
```