### PR TITLE
Set alpha to 255 in the x86 yuv_p16_to_rgb8 paths

### DIFF
--- a/src/avx2/yuv_p16_to_rgb8.rs
+++ b/src/avx2/yuv_p16_to_rgb8.rs
@@ -109,7 +109,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
 
     let dst_ptr = bgra;
 
-    let v_max_colors = _mm256_set1_epi16((1i16 << BIT_DEPTH as i16) - 1);
+    let v_alpha = _mm256_set1_epi8(255u8 as i8);
 
     let y_corr = _mm256_set1_epi16(bias_y as i16);
     let uv_corr = _mm256_set1_epi16(bias_uv as i16);
@@ -266,7 +266,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
             r_values0,
             g_values0,
             b_values0,
-            v_max_colors,
+            v_alpha,
         );
 
         cx += 32;
@@ -370,7 +370,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
             r_values,
             g_values,
             b_values,
-            v_max_colors,
+            v_alpha,
         );
 
         cx += 16;

--- a/src/avx512bw/yuv_p16_to_rgb8.rs
+++ b/src/avx512bw/yuv_p16_to_rgb8.rs
@@ -189,7 +189,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
 
     let dst_ptr = bgra;
 
-    let v_max_colors = _mm512_set1_epi16((1i16 << BIT_DEPTH as i16) - 1);
+    let v_alpha = _mm512_set1_epi8(255u8 as i8);
 
     let y_corr = _mm512_set1_epi16(bias_y as i16);
     let uv_corr = _mm512_set1_epi16(bias_uv as i16);
@@ -339,7 +339,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
             r_values0,
             g_values0,
             b_values0,
-            v_max_colors,
+            v_alpha,
         );
 
         cx += 64;
@@ -433,7 +433,7 @@ unsafe fn avx_yuv_p16_to_rgba_row8_impl<
             r_values,
             g_values,
             b_values,
-            v_max_colors,
+            v_alpha,
         );
 
         cx += 32;

--- a/src/sse/yuv_p16_to_rgb8.rs
+++ b/src/sse/yuv_p16_to_rgb8.rs
@@ -108,7 +108,7 @@ unsafe fn sse_yuv_p16_to_rgba8_row_impl<
 
     let dst_ptr = bgra;
 
-    let v_max_colors = _mm_set1_epi16((1i16 << BIT_DEPTH as i16) - 1);
+    let v_alpha = _mm_set1_epi8(255u8 as i8);
 
     let y_corr = _mm_set1_epi16(bias_y as i16);
     let uv_corr = _mm_set1_epi16(bias_uv as i16);
@@ -215,7 +215,7 @@ unsafe fn sse_yuv_p16_to_rgba8_row_impl<
             r_values,
             g_values,
             b_values,
-            v_max_colors,
+            v_alpha,
         );
 
         cx += 8;


### PR DESCRIPTION
Using the max value for the specified bit depth was resulting in alternating alpha values between 0xFF and 0x03 or 0x0F depending on the bit depth.